### PR TITLE
add exclude-substrings flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Full examples of usage scripts are following:
 # for prometheus pushgateway
 export PROM_ADDRESS="localhost:9091"
 export PROM_JOB=pushgateway
-./bblfsh-performance end-to-end --language=go --commit=3d9682b --extension=".go" --storage="prom" /var/testdata/benchmarks
+./bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --exclude-suffixes=".legacy",".native",".uast" --storage="prom" /var/testdata/benchmarks
 
 # for influx db
 export INFLUX_ADDRESS="http://localhost:8086"
@@ -80,15 +80,15 @@ export INFLUX_USERNAME=""
 export INFLUX_PASSWORD=""
 export INFLUX_DB=mydb
 export INFLUX_MEASUREMENT=benchmark
-bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --extension=".go" --storage="influxdb" /var/testdata/benchmarks
+bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --exclude-suffixes=".legacy",".native",".uast" --storage="influxdb" /var/testdata/benchmarks
 
 Flags:
-  -c, --commit string          commit id that's being tested and will be used as a tag in performance report
-      --custom-driver          if this flag is set to true CLI pulls corresponding language driver repo's commit, builds docker image and installs it onto the bblfsh container
-  -t, --docker-tag string      bblfshd docker image tag to be tested (default "latest-drivers")
-  -e, --extension string       file extension to be filtered
-      --filter-prefix string   file prefix to be filtered (default "bench_")
-  -h, --help                   help for end-to-end
-  -l, --language string        name of the language to be tested
-  -s, --storage string         storage kind to store the results(prom, influxdb, file) (default "prom")
+  -c, --commit string              commit id that's being tested and will be used as a tag in performance report
+      --custom-driver              if this flag is set to true CLI pulls corresponding language driver repo's commit, builds docker image and installs it onto the bblfsh container
+  -t, --docker-tag string          bblfshd docker image tag to be tested (default "latest-drivers")
+      --exclude-suffixes strings   file suffixes to be excluded (default [.legacy,.native,.uast])
+      --filter-prefix string       file prefix to be filtered (default "bench_")
+  -h, --help                       help for end-to-end
+  -l, --language string            name of the language to be tested
+  -s, --storage string             storage kind to store the results(prom, influxdb, file) (default "prom")
 ```

--- a/cmd/bblfsh-performance/endtoend/endtoend.go
+++ b/cmd/bblfsh-performance/endtoend/endtoend.go
@@ -55,7 +55,7 @@ Full examples of usage scripts are following:
 # for prometheus pushgateway
 export PROM_ADDRESS="localhost:9091"
 export PROM_JOB=pushgateway
-./bblfsh-performance end-to-end --language=go --commit=3d9682b --extension=".go" --storage="prom" /var/testdata/benchmarks
+./bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --exclude-suffixes=".legacy",".native",".uast" --storage="prom" /var/testdata/benchmarks
 
 # for influx db
 export INFLUX_ADDRESS="http://localhost:8086"
@@ -63,11 +63,11 @@ export INFLUX_USERNAME=""
 export INFLUX_PASSWORD=""
 export INFLUX_DB=mydb
 export INFLUX_MEASUREMENT=benchmark
-bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --extension=".go" --storage="influxdb" /var/testdata/benchmarks`,
+bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="bench_" --exclude-suffixes=".legacy",".native",".uast" --storage="influxdb" /var/testdata/benchmarks`,
 		RunE: performance.RunESilenced(func(cmd *cobra.Command, args []string) error {
 			language, _ := cmd.Flags().GetString("language")
 			commit, _ := cmd.Flags().GetString("commit")
-			extension, _ := cmd.Flags().GetString("extension")
+			excludeSubstrings, _ := cmd.Flags().GetStringSlice("exclude-suffixes")
 			stor, _ := cmd.Flags().GetString("storage")
 			filterPrefix, _ := cmd.Flags().GetString("filter-prefix")
 			customDriver, _ := cmd.Flags().GetBool("custom-driver")
@@ -121,7 +121,7 @@ bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="be
 			}
 			defer client.Close()
 
-			files, err := performance.GetFiles(filterPrefix, extension, args...)
+			files, err := performance.GetFiles(filterPrefix, excludeSubstrings, args...)
 			if err != nil {
 				return errGetFiles.Wrap(err)
 			} else if len(files) == 0 {
@@ -168,7 +168,7 @@ bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="be
 	flags := cmd.Flags()
 	flags.StringP("language", "l", "", "name of the language to be tested")
 	flags.StringP("commit", "c", "", "commit id that's being tested and will be used as a tag in performance report")
-	flags.StringP("extension", "e", "", "file extension to be filtered")
+	flags.StringSlice("exclude-suffixes", []string{".legacy", ".native", ".uast"}, "file suffixes to be excluded")
 	flags.StringP("docker-tag", "t", bblfshDefaultConfTag, "bblfshd docker image tag to be tested")
 	flags.String("filter-prefix", fileFilterPrefix, "file prefix to be filtered")
 	flags.StringP("storage", "s", prom_pushgateway.Kind, "storage kind to store the results"+

--- a/common.go
+++ b/common.go
@@ -73,16 +73,31 @@ func RunESilenced(f RunE) RunE {
 	}
 }
 
+func stringInSlice(s string, strSlice []string) bool {
+	for _, sl := range strSlice {
+		if strings.HasSuffix(s, sl) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetFiles is a simple "get files by pattern" function
 // Purpose: filter required fixtures
-func GetFiles(pref, ext string, dirs ...string) ([]string, error) {
+func GetFiles(pref string, exclusionSuffixes []string, dirs ...string) ([]string, error) {
 	var res []string
 	for _, d := range dirs {
-		matches, err := filepath.Glob(filepath.Join(d, pref+"*"+ext))
+		matches, err := filepath.Glob(filepath.Join(d, pref+"*"))
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, matches...)
+
+		for _, m := range matches {
+			if stringInSlice(m, exclusionSuffixes) {
+				continue
+			}
+			res = append(res, m)
+		}
 	}
 	return res, nil
 }


### PR DESCRIPTION
Previous version of performance CLI was working with file extensions, however now it should be run inside the Jenkins environment, at the same time Jenkinsfile will be generated from SDK that does not have such metadata as extension. Thus extensions flag was changed to exclude-substrings. Default values are set with the respect to a fixtures suite of every driver, excluding files with AST contents.

Signed-off-by: lwsanty <lwsanty@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/performance/16)
<!-- Reviewable:end -->
