### PR TITLE
trim prefixes

### DIFF
--- a/cmd/bblfsh-performance/endtoend/endtoend.go
+++ b/cmd/bblfsh-performance/endtoend/endtoend.go
@@ -143,7 +143,7 @@ bblfsh-performance end-to-end --language=go --commit=3d9682b --filter-prefix="be
 				if err != nil {
 					return errBenchmark.New(f, err)
 				}
-				benchmarks = append(benchmarks, performance.BenchmarkResultToBenchmark(f, bRes))
+				benchmarks = append(benchmarks, performance.BenchmarkResultToBenchmark(f, bRes, filterPrefix))
 			}
 
 			// store data

--- a/common.go
+++ b/common.go
@@ -33,25 +33,28 @@ type Benchmark struct {
 }
 
 // NewBenchmark is a constructor for Benchmark
-func NewBenchmark(pb *parse.Benchmark) Benchmark {
-	pb.Name = parseBenchmarkName(pb.Name)
+func NewBenchmark(pb *parse.Benchmark, trimPrefixes ...string) Benchmark {
+	pb.Name = parseBenchmarkName(pb.Name, trimPrefixes...)
 	return Benchmark{*pb}
 }
 
 // BenchmarkResultToBenchmark converts b *testing.BenchmarkResult *parse.Benchmark for further storing
-func BenchmarkResultToBenchmark(name string, b *testing.BenchmarkResult) Benchmark {
+func BenchmarkResultToBenchmark(name string, b *testing.BenchmarkResult, trimPrefixes ...string) Benchmark {
 	return NewBenchmark(&parse.Benchmark{
 		Name:              name,
 		N:                 b.N,
 		NsPerOp:           float64(b.NsPerOp()),
 		AllocedBytesPerOp: uint64(b.AllocedBytesPerOp()),
 		AllocsPerOp:       uint64(b.AllocsPerOp()),
-	})
+	}, trimPrefixes...)
 }
 
 // parseBenchmarkName removes the path and suffixes from benchmark info
 // Example: BenchmarkGoDriver/transform/accumulator_factory-4 -> accumulator_factory
-func parseBenchmarkName(name string) string {
+func parseBenchmarkName(name string, trimPrefixes ...string) string {
+	for _, tp := range trimPrefixes {
+		name = strings.TrimPrefix(name, tp)
+	}
 	if i := strings.LastIndex(name, "/"); i >= 0 {
 		name = name[i+1:]
 	}


### PR DESCRIPTION
during e2e command execution all files contain same prefix, this fix trims that prefix
closes #19

Signed-off-by: lwsanty <lwsanty@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/performance/20)
<!-- Reviewable:end -->
